### PR TITLE
update kraken.py to support compressed input

### DIFF
--- a/recentrifuge/kraken.py
+++ b/recentrifuge/kraken.py
@@ -7,6 +7,7 @@ import collections as col
 import io
 import os
 import re
+import fileinput
 from math import log10
 from statistics import mean
 from typing import Tuple, Counter, Dict, List, Set
@@ -49,7 +50,7 @@ def read_kraken_output(output_file: Filename,
     num_errors: int = 0  # Number or reads discarded due to error
     output.write(gray(f'Loading output file {output_file}... '))
     try:
-        with open(output_file, 'r') as file:
+        with fileinput.input(output_file, openhook=fileinput.hook_compressed) as file:
             # Check number of cols in header
             header = file.readline().split('\t')
             if len(header) != 5:


### PR DESCRIPTION
The kraken output file could be very large (hundreds of Mb or even larger), so I think it could be more disk efficient if recentrifuge could read compressed as well as uncompressed kraken outputs.

So I just use fileinput to read compressed as well as uncompressed kraken output files, the code is simple:

# import library fileinput in the beginning
`import fileinput`
# use fileinput to read kraken output file by using `openhook=fileinput.hook_compressed`
`with fileinput.input(output_file, openhook=fileinput.hook_compressed) as file:`